### PR TITLE
fix: prettier dev dependancy

### DIFF
--- a/baseProject/package.json
+++ b/baseProject/package.json
@@ -79,6 +79,7 @@
     "lint-staged": "^14.0.1",
     "metro-react-native-babel-preset": "0.77.0",
     "prettier": "^3.0.3",
+    "eslint-plugin-prettier": "5.0.0",
     "react-test-renderer": "18.2.0",
     "sort-package-json": "^2.6.0",
     "typescript": "5.2.2"


### PR DESCRIPTION
This is fixing the incompatibility between prettier 3 and eslint-plugin-prettier 4.

Official issue: https://github.com/prettier/eslint-plugin-prettier/issues/562
https://stackoverflow.com/a/76625797
