### PR TITLE
fix: storybook init process

### DIFF
--- a/baseProject/config/storybook/main.ts
+++ b/baseProject/config/storybook/main.ts
@@ -22,14 +22,14 @@ const config: StorybookConfig = {
     autodocs: 'tag',
   },
 
-  webpackFinal: async config => {
-    if (config.resolve) {
-      config.resolve.alias = {
-        ...config.resolve.alias,
+  webpackFinal: async cfg => {
+    if (cfg.resolve) {
+      cfg.resolve.alias = {
+        ...cfg.resolve.alias,
         'react-native$': 'react-native-web',
       };
     }
-    return config;
+    return cfg;
   },
 };
 

--- a/baseProject/config/storybook/preview.js
+++ b/baseProject/config/storybook/preview.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/react-in-jsx-scope */
 {{#if hasGluestackUICore}}
 import { GluestackUIProvider } from '@gluestack-ui/themed';
 import { StyleSheet, View } from 'react-native';

--- a/baseProject/config/storybook/preview.tsx
+++ b/baseProject/config/storybook/preview.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/react-in-jsx-scope */
 import type { Preview } from '@storybook/react';
 {{#if hasGluestackUICore}}
 import { GluestackUIProvider } from '@gluestack-ui/themed';
@@ -9,7 +10,7 @@ import { StyleSheet, View } from 'react-native';
   {{#if hasGluestackUIDefaultTheme}}
   import {config } from '@gluestack-ui/config';
   {{else if hasGluestackUIEjected}}
-  import { config } from '../config/gluestack-ui.config';
+  import { config } from 'config/gluestack-ui.config';
   {{/if}}
 {{/if}}
 

--- a/src/commands/start-project.ts
+++ b/src/commands/start-project.ts
@@ -50,7 +50,7 @@ const showHelp = () => {
 };
 
 const startProject = async (toolbox: RnBootstrapToolbox) => {
-  const { prompt, print, filesystem } = toolbox;
+  const { prompt, print, filesystem, replaceFile } = toolbox;
 
   const projectName = toolbox.getProjectName();
   const bundleId = toolbox.getBundleId();
@@ -157,7 +157,9 @@ const startProject = async (toolbox: RnBootstrapToolbox) => {
     const packageJson = filesystem.read(packageJsonPath, 'json');
     packageJson.scripts['storybook:mobile'] =
       "cross-env STORYBOOK_ENABLED='true' yarn start";
-    filesystem.write(packageJsonPath, packageJson, { jsonIndent: 2 });
+    filesystem.write(packageJsonPath, packageJson, {
+      jsonIndent: 2
+    });
 
     // Check if vite is selected
     const isViteSelected =
@@ -165,22 +167,6 @@ const startProject = async (toolbox: RnBootstrapToolbox) => {
     isViteSelected && (await spawnProgress('yarn add vite --dev'));
 
     //Replace storybook files with preconfigured ones
-    const replaceFile = (sourceFile: string, destinationFile: string) => {
-      const sourceDirectory = filesystem.path(
-        process.cwd(),
-        'config',
-        'storybook',
-        sourceFile
-      );
-      const destinationDirectory = filesystem.path(
-        process.cwd(),
-        destinationFile
-      );
-      filesystem.copy(sourceDirectory, destinationDirectory, {
-        overwrite: true
-      });
-    };
-
     if (isViteSelected) {
       const viteConfigPath = filesystem.path(process.cwd(), 'vite.config.ts');
       filesystem.write(viteConfigPath, '');
@@ -198,9 +184,15 @@ const startProject = async (toolbox: RnBootstrapToolbox) => {
       );
       replaceFile('preview.js', '.storybookMobile/preview.js');
     }
+
+    print.info('Removing storybook config folder reference...');
+    toolbox.filesystem.remove('config/storybook');
+    print.success(
+      print.checkmark + ' Storybook config folder reference removed!'
+    );
   }
 
-  print.success('Setup is done.');
+  print.success(print.checkmark + ' Setup is done.');
 };
 
 module.exports = command;

--- a/src/extensions/replace-file.ts
+++ b/src/extensions/replace-file.ts
@@ -1,0 +1,23 @@
+import { RnBootstrapToolbox } from '../types/RnBootstrapToolbox';
+
+module.exports = (toolbox: RnBootstrapToolbox) => {
+  const { filesystem } = toolbox;
+
+  const replaceFile = (sourceFile: string, destinationFile: string) => {
+    const sourceDirectory = filesystem.path(
+      process.cwd(),
+      'config',
+      'storybook',
+      sourceFile
+    );
+    const destinationDirectory = filesystem.path(
+      process.cwd(),
+      destinationFile
+    );
+    filesystem.copy(sourceDirectory, destinationDirectory, {
+      overwrite: true
+    });
+  };
+
+  toolbox.replaceFile = replaceFile;
+};

--- a/src/types/RnBootstrapToolbox.ts
+++ b/src/types/RnBootstrapToolbox.ts
@@ -15,6 +15,7 @@ export interface RnBootstrapToolbox
   ): void;
   renameProject(projectName: string, bundleIdentifier: string): Promise<string>;
   getProjectName(): string | never;
+  replaceFile(sourceFile: string, destinationFile: string): void;
   getBundleId(): string | never;
   makeRcFile(selectedOptions: StartProjectOptionSelectionResult): void;
   CLI_PATH: string;


### PR DESCRIPTION
## Description

This change is improving overall storybook initialization logic.

## Related Issue

Reference storybook folder not being deleted after setup is complete.

## Proposed Changes

- Refactor storybook init logic and remove reference folder after process completes.

## Screenshots (if appropriate)

N/A

## Checklist

- [x] I have performed a self-review of my code.
- [x] My code follows the project's coding standards.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding CLI changes to the documentation.
- [x] My changes generate no new warnings or errors.
- [x] I have tested the CLI with my changes locally.
- [x] baseProject is fully functional on both Android & iOS.

## Additional Information

Tested with webpack & vite
