### PR TITLE
fix: added missing storybook metro config

### DIFF
--- a/baseProject/metro.config.js
+++ b/baseProject/metro.config.js
@@ -14,6 +14,15 @@ const defaultConfig = getDefaultConfig(__dirname);
 let config = {};
 {{#if hasStorybook}}
 
+const storybookSourceExt =
+  process.env.STORYBOOK_ENABLED === 'true'
+    ? ['storybook.tsx', 'storybook.ts', 'storybook.js', 'storybook.jsx']
+    : [];
+
+if (process.env.STORYBOOK_ENABLED) {
+  defaultConfig.resolver.sourceExts = [...storybookSourceExt, ...defaultConfig.resolver.sourceExts];
+}
+
 generate({
     configPath: path.resolve(__dirname, './.storybook'),
   });


### PR DESCRIPTION
## Description

Fixed missing storybook metro config.

## Related Issue

- Storybook unable to start via yarn storybook command 

## Proposed Changes

- The Storybook variable was unintentionally omitted from the Metro config after updating Storybook to version 7.6.*

## Screenshots (if appropriate)

Please attach any screenshots or images if they help in understanding the changes.

## Checklist

- [x] I have performed a self-review of my code.
- [x] My code follows the project's coding standards.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding CLI changes to the documentation.
- [x] My changes generate no new warnings or errors.
- [x] I have tested the CLI with my changes locally.
- [x] baseProject is fully functional on both Android & iOS.

## Additional Information

Any additional information or context that could be relevant to the reviewer.
