### PR TITLE
Chore: add storybook examples option

### DIFF
--- a/src/commands/start-project.ts
+++ b/src/commands/start-project.ts
@@ -112,7 +112,7 @@ const startProject = async (toolbox: RnBootstrapToolbox) => {
     }
   }
 
-  if (selectedOptions.storybook === StorybookChoice.withStorybook) {
+  if (selectedOptions.storybook !== StorybookChoice.NoStorybook) {
     print.highlight('Creating storybook...');
     await spawnProgress('npx sb@latest init');
 
@@ -125,18 +125,22 @@ const startProject = async (toolbox: RnBootstrapToolbox) => {
       jsonIndent: 2
     });
 
-    if (gluestackOptions.includes(selectedOptions.styleLibrary)) {
-      // Replace storybook files with preconfigured ones specific for gluestack
-      replaceFile('preview.tsx', '.storybook/preview.tsx');
+    if (selectedOptions.storybook === StorybookChoice.StorybookWithStories) {
+      if (gluestackOptions.includes(selectedOptions.styleLibrary)) {
+        // Replace storybook files with preconfigured ones specific for gluestack
+        replaceFile('preview.tsx', '.storybook/preview.tsx');
+        filesystem.remove('.storybook/stories/');
+        replaceFile('gluestackStories', '.storybook/stories');
+      }
+  
+      print.info('Removing storybook config folder reference...');
+      toolbox.filesystem.remove('config/storybook');
+      print.highlight(
+        print.checkmark + ' Storybook config folder reference removed!'
+      );
+    } else {
       filesystem.remove('.storybook/stories/');
-      replaceFile('gluestackStories', '.storybook/stories');
     }
-
-    print.info('Removing storybook config folder reference...');
-    toolbox.filesystem.remove('config/storybook');
-    print.highlight(
-      print.checkmark + ' Storybook config folder reference removed!'
-    );
   }
 
   IS_MAC && (await yarn.run('pod-install'));

--- a/src/tools/options.ts
+++ b/src/tools/options.ts
@@ -21,8 +21,9 @@ export enum StyleLibraryChoice {
 }
 
 export enum StorybookChoice {
-  withStorybook = 'Yes',
-  withoutStorybook = 'No'
+  Storybook = 'Storybook no examples',
+  StorybookWithStories = 'Storybook with Stories example',
+  NoStorybook = 'No Storybook' 
 }
 
 export enum StateLibraryChoice {
@@ -55,7 +56,8 @@ export const SelectionToDependencyNameMap = {
 
 export const SelectionToDevDependencyNameMap = {
   [StyleLibraryChoice.StyledComponents]: styleDevDeps,
-  [StorybookChoice.withStorybook]: storybookDevDeps,
+  [StorybookChoice.Storybook]: storybookDevDeps,
+  [StorybookChoice.StorybookWithStories]: storybookDevDeps,
   [ReactotronChoice.withReactotron]: reactotronDevDeps
 };
 
@@ -82,11 +84,12 @@ export const SelectionToTemplateParamsMap: Partial<Record<
   [StyleLibraryChoice.StyledComponents]: {
     hasStyledComponents: true
   },
-  [StorybookChoice.withStorybook]: {
-    hasStorybook: true
+  [StorybookChoice.Storybook]: {
+    hasStorybook: true,
   },
-  [StorybookChoice.withoutStorybook]: {
-    hasStorybook: false
+  [StorybookChoice.StorybookWithStories]: {
+    hasStorybook: true,
+    hasStorybookExample: true
   },
   [StateLibraryChoice.ReduxToolkit]: {
     hasReduxToolkit: true
@@ -119,7 +122,10 @@ const getFileNameMatcher = (fileName: string) => {
 // Paths from unselected options get skipped when copying the baseProject
 // You can also specify individual file names as strings
 export const SelectionToOptionalFilePathsMap = {
-  [StorybookChoice.withStorybook]: [
+  [StorybookChoice.Storybook]: [
+    getFileNameMatcher('App.storybook.tsx')
+  ],
+  [StorybookChoice.StorybookWithStories]: [
     getFullPathMatcher('config/storybook/'),
     getFileNameMatcher('App.storybook.tsx')
   ],
@@ -152,6 +158,7 @@ export const DefaultTemplateParams: TemplateParams = {
   hasGluestackUIEjected: false,
   hasStyledComponents: false,
   hasStorybook: false,
+  hasStorybookExample: false,
   hasReduxToolkit: false,
   hasRTKQuery: false,
   hasReactotron: false,

--- a/src/types/BaseProjectTemplateParams.ts
+++ b/src/types/BaseProjectTemplateParams.ts
@@ -4,6 +4,7 @@ export interface TemplateParams {
   hasGluestackUIDefaultTheme: boolean;
   hasGluestackUIEjected: boolean;
   hasStorybook: boolean;
+  hasStorybookExample: boolean;
   hasReduxToolkit: boolean;
   hasRTKQuery: boolean;
   hasStyledComponents: boolean;


### PR DESCRIPTION
## Description

Added the option to choose whether to include example stories or not

## Related Issue

- N/A

## Proposed Changes

- added the option to select storybook without set up example stories

## Screenshots (if appropriate)

N/A

## Checklist

- [x] I have performed a self-review of my code.
- [x] My code follows the project's coding standards.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding CLI changes to the documentation.
- [x] My changes generate no new warnings or errors.
- [x] I have tested the CLI with my changes locally.
- [x] baseProject is fully functional on both Android & iOS.

## Additional Information

N/A
