### PR TITLE
fix: internationalization change button missing conditional rendering

### DIFF
--- a/baseProject/src/features/home/component/HomeComponent.tsx
+++ b/baseProject/src/features/home/component/HomeComponent.tsx
@@ -48,14 +48,14 @@ const Body: FunctionComponent = () => {
     {{#if hasI18n}}
       <View>
         <Section title={t('Step One')}>
-          {t('Edit')} {<Text style={styles.highlight}>App.tsx</Text>} {t('Screen Change')}
+          {t('Edit')} {{#if hasStyledComponents}}<HighlightedText>App.tsx</HighlightedText>{{else}}<Text style={styles.highlight}>App.tsx</Text>{{/if}} {t('Screen Change')}
         </Section>
         <Section title={t('See Your Changes')}>
-          {t('Press')} {<Text style={styles.highlight}>Cmd + R</Text>} {t('Simulator')} {t('Reload')}
+          {t('Press')} {{#if hasStyledComponents}}<HighlightedText>Cmd + R</HighlightedText>{{else}}<Text style={styles.highlight}>Cmd + R</Text>{{/if}} {t('Simulator')} {t('Reload')}
         </Section>
         <Section title={t('Debug')}>
-          {t('Press')} {<Text style={styles.highlight}>Cmd + D</Text>} {t('Simulator')} {t('Or')}{' '}
-          {<Text style={styles.highlight}>{t('Shake')}</Text>} {t('Dev Menu')}
+          {t('Press')} {{#if hasStyledComponents}}<HighlightedText>Cmd + D</HighlightedText>{{else}}<Text style={styles.highlight}>Cmd + D</Text>{{/if}} {t('Simulator')} {t('Or')}{' '}
+          {{#if hasStyledComponents}}<HighlightedText>{t('Shake')}</HighlightedText>{{else}}<Text style={styles.highlight}>{t('Shake')}</Text>{{/if}} {t('Dev Menu')}
         </Section>
         <Section title={t('Learn More')}>{t('Read Docs')}</Section>
         <LearnMoreLinks />
@@ -88,7 +88,9 @@ export const HomeComponent = () => {
   return (
     <ScrollView contentInsetAdjustmentBehavior="automatic" style={backgroundStyle}> 
       {{#unless hasReactNavigationExample}} 
+      {{#if hasI18n}}
       <ChangeLanguage />
+      {{/if}}
       {{/unless}}     
       <Header />
       <Body />


### PR DESCRIPTION
## Description

Fix for the internationalization option with different styling options and conditions to render.

## Related Issue

- Link to the related issue (if applicable)

## Proposed Changes

- Added more conditions to be met and refactored the home screen component to be able to render based on different styling options chosen.

## Screenshots (if appropriate)

Please attach any screenshots or images if they help in understanding the changes.

## Checklist

- [✅] I have performed a self-review of my code.
- [✅] My code follows the project's coding standards.
- [✅] I have commented my code, particularly in hard-to-understand areas.
- [✅] I have made corresponding CLI changes to the documentation.
- [✅] My changes generate no new warnings or errors.
- [✅] I have tested the CLI with my changes locally.
- [✅] baseProject is fully functional on both Android & iOS.

## Additional Information

Any additional information or context that could be relevant to the reviewer.
